### PR TITLE
Fix sdl2 version range in harfbuzz-freetype example dependencies

### DIFF
--- a/harfbuzz-freetype/harfbuzz-freetype.cabal
+++ b/harfbuzz-freetype/harfbuzz-freetype.cabal
@@ -61,7 +61,7 @@ executable example
     linear,
     ptrdiff,
     random,
-    sdl2 >= 2.4.1,
+    sdl2 >= 2.4.1 && < 2.5,
     StateVar,
     text,
     vector


### PR DESCRIPTION
Currently, example does not compile with the latest version of `sdl2`, thus an upper range.