### PR TITLE
Make parsnip build with GHC 8.6 through 8.10

### DIFF
--- a/parsnip/parsnip.cabal
+++ b/parsnip/parsnip.cabal
@@ -47,7 +47,7 @@ common base
   c-sources: cbits/parsnip.c
   build-depends:
     attoparsec,
-    base >= 4.15 && < 5,
+    base >= 4.12 && < 5,
     bytestring,
     containers,
     data-default,

--- a/parsnip/src/Text/Parsnip/Internal/Parser.hs
+++ b/parsnip/src/Text/Parsnip/Internal/Parser.hs
@@ -33,9 +33,13 @@ module Text.Parsnip.Internal.Parser
 (
 -- * Parser
   Parser(..)
+#if __GLASGOW_HASKELL__ >= 810
+, Option(Option#, Some, None)
+#else
 , Option
 , pattern Some
 , pattern None
+#endif
 , mapOption, setOption
 , Result, pattern OK, pattern Fail
 , mapResult, setResult

--- a/parsnip/src/Text/Parsnip/Internal/Parser.hs
+++ b/parsnip/src/Text/Parsnip/Internal/Parser.hs
@@ -22,14 +22,20 @@
 {-# language UnboxedTuples #-}
 {-# language MagicHash #-}
 {-# language PatternSynonyms #-}
+
+#if __GLASGOW_HASKELL__ >= 810
 {-# language UnliftedNewtypes #-}
+#endif
+
 {-# options_ghc -O2 #-}
 
 module Text.Parsnip.Internal.Parser
 (
 -- * Parser
   Parser(..)
-, Option(Option#,Some,None)
+, Option
+, pattern Some
+, pattern None
 , mapOption, setOption
 , Result, pattern OK, pattern Fail
 , mapResult, setResult
@@ -67,6 +73,9 @@ import Text.Parsnip.Internal.Private
 --------------------------------------------------------------------------------
 
 -- | Unlifted 'Maybe'
+
+#if __GLASGOW_HASKELL__ >= 810
+
 newtype Option a = Option# (# a | (##) #)
 
 pattern Some :: a -> Option a
@@ -74,6 +83,18 @@ pattern Some a = Option# (# a | #)
 
 pattern None :: Option a
 pattern None = Option# (# | (##) #)
+
+#else
+
+type Option a = (# a | (##) #)
+
+pattern Some :: a -> Option a
+pattern Some a = (# a | #)
+
+pattern None :: Option a
+pattern None = (# | (##) #)
+
+#endif
 
 {-# complete Some, None #-} -- these don't work outside this module =(
 

--- a/parsnip/src/Text/Parsnip/Internal/Private.hs
+++ b/parsnip/src/Text/Parsnip/Internal/Private.hs
@@ -4,7 +4,6 @@
 {-# language BangPatterns #-}
 {-# language ViewPatterns #-}
 {-# language UnliftedFFITypes #-}
-{-# language UnliftedNewtypes #-}
 
 -- | the proverbial junk drawer
 module Text.Parsnip.Internal.Private


### PR DESCRIPTION
GHC 8.6 and 8.8 don't have unlifted newtypes, so Option is a type synonym for those versions.

There are no tests, so I haven't tested this.  It builds across all versions, though.